### PR TITLE
make yarman accessible through any IP the host has

### DIFF
--- a/scriptmodules/supplementary/yarman_default.sh
+++ b/scriptmodules/supplementary/yarman_default.sh
@@ -26,9 +26,9 @@ function install_bin_yarman() {
 function configure_yarman() {
     killall php
     echo $user > "$md_inst/data/user"
-    php -S "$(ip route get 8.8.8.8 | head -1 | cut -d' ' -f8):8080" -t "$md_inst" > /dev/null 2>&1 &
+    php -S 0.0.0.0:8080 -t "$md_inst" > /dev/null 2>&1 &
 
-    local config="php -S \"\$\(ip route get 8.8.8.8 \| head -1 \| cut -d' ' -f8\):8080\" -t \"$md_inst\" > /dev/null 2>\&1 \&"
+    local config="php -S 0.0.0.0:8080 -t \"$md_inst\" > /dev/null 2>\&1 \&"
     sed -i "/^php/d" /etc/rc.local
     sed -i "s|^exit 0$|${config}\\nexit 0|" /etc/rc.local
 }


### PR DESCRIPTION
Using a "real" IP when launching 'php -S' will make it accessible only in that IP. I noticed that when tried to access it using `http://localhost:8080` and it wasn't accessible. I had to use the same IP I used in the php command (`192.168.blablabla`).

I think you should use `0.0.0.0`, which means `every IPv4 address in this host`. It makes yarman accessible via `localhost` and any other IP the host has.